### PR TITLE
Fix binary file handling

### DIFF
--- a/nodes/Eml/operations/eml/functions/EmlCompose.ts
+++ b/nodes/Eml/operations/eml/functions/EmlCompose.ts
@@ -187,7 +187,7 @@ export const composeEmlOperation: IResourceOperationDef = {
           const propertyName = attachments[i].trim();
           if (propertyName in item.binary) {
             const binaryMeta: IBinaryData = item.binary[propertyName];
-            const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
+            const binaryData = await context.helpers.getBinaryDataBuffer(itemIndex, propertyName);
             
             const fileName = binaryMeta.fileName || propertyName;
 
@@ -224,7 +224,7 @@ export const composeEmlOperation: IResourceOperationDef = {
           const propertyName = inlineAttachments[i].trim();
           if (propertyName in item.binary) {
             const binaryMeta: IBinaryData = item.binary[propertyName];
-            const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
+            const binaryData = await context.helpers.getBinaryDataBuffer(itemIndex, propertyName);
             
             const fileName = binaryMeta.fileName || propertyName;
 

--- a/nodes/Eml/operations/eml/functions/EmlCompose.ts
+++ b/nodes/Eml/operations/eml/functions/EmlCompose.ts
@@ -187,7 +187,7 @@ export const composeEmlOperation: IResourceOperationDef = {
           const propertyName = attachments[i].trim();
           if (propertyName in item.binary) {
             const binaryMeta: IBinaryData = item.binary[propertyName];
-						const binaryData = await this.helpers.getBinaryDataBuffer(0, propertyName);
+						const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
             
             const fileName = binaryMeta.fileName || propertyName;
 
@@ -224,7 +224,7 @@ export const composeEmlOperation: IResourceOperationDef = {
           const propertyName = inlineAttachments[i].trim();
           if (propertyName in item.binary) {
             const binaryMeta: IBinaryData = item.binary[propertyName];
-						const binaryData = await this.helpers.getBinaryDataBuffer(0, propertyName);
+						const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
             
             const fileName = binaryMeta.fileName || propertyName;
 

--- a/nodes/Eml/operations/eml/functions/EmlCompose.ts
+++ b/nodes/Eml/operations/eml/functions/EmlCompose.ts
@@ -187,7 +187,7 @@ export const composeEmlOperation: IResourceOperationDef = {
           const propertyName = attachments[i].trim();
           if (propertyName in item.binary) {
             const binaryMeta: IBinaryData = item.binary[propertyName];
-						const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
+            const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
             
             const fileName = binaryMeta.fileName || propertyName;
 
@@ -224,7 +224,7 @@ export const composeEmlOperation: IResourceOperationDef = {
           const propertyName = inlineAttachments[i].trim();
           if (propertyName in item.binary) {
             const binaryMeta: IBinaryData = item.binary[propertyName];
-						const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
+            const binaryData = await context.helpers.getBinaryDataBuffer(0, propertyName);
             
             const fileName = binaryMeta.fileName || propertyName;
 

--- a/nodes/Eml/operations/eml/functions/EmlCompose.ts
+++ b/nodes/Eml/operations/eml/functions/EmlCompose.ts
@@ -186,14 +186,15 @@ export const composeEmlOperation: IResourceOperationDef = {
         for (let i = 0; i < attachments.length; i++) {
           const propertyName = attachments[i].trim();
           if (propertyName in item.binary) {
-            const binaryData: IBinaryData = item.binary[propertyName];
+            const binaryMeta: IBinaryData = item.binary[propertyName];
+						const binaryData = await this.helpers.getBinaryDataBuffer(0, propertyName);
             
-            const fileName = binaryData.fileName || propertyName;
+            const fileName = binaryMeta.fileName || propertyName;
 
             let newAttachment: Mail.Attachment = {
               filename: fileName,
-              content: binaryData.data,
-              contentType: binaryData.mimeType,
+              content: binaryData,
+              contentType: binaryMeta.mimeType,
               encoding: 'base64',
             };
             
@@ -222,15 +223,16 @@ export const composeEmlOperation: IResourceOperationDef = {
         for (let i = 0; i < inlineAttachments.length; i++) {
           const propertyName = inlineAttachments[i].trim();
           if (propertyName in item.binary) {
-            const binaryData: IBinaryData = item.binary[propertyName];
+            const binaryMeta: IBinaryData = item.binary[propertyName];
+						const binaryData = await this.helpers.getBinaryDataBuffer(0, propertyName);
             
-            const fileName = binaryData.fileName || propertyName;
+            const fileName = binaryMeta.fileName || propertyName;
 
             let newAttachment: Mail.Attachment = {
               cid: fileName,
               filename: fileName,
-              content: binaryData.data,
-              contentType: binaryData.mimeType,
+              content: binaryData,
+              contentType: binaryMeta.mimeType,
               contentDisposition: 'inline',
               encoding: 'base64',
             };


### PR DESCRIPTION
I also faced problems with attaching PDFs (~220kb) as attachments to the emails (using n8n `2.6.1`).

Hint from this comment https://github.com/umanamente/n8n-nodes-eml/issues/2#issuecomment-3650986315 fixed issue for me, so I made a PR.

Temporary published [my fork to NPM](https://www.npmjs.com/package/n8n-nodes-eml-fixed-attachments) to continue building my workflows.